### PR TITLE
Remove obsolete comment from FAA_INSPECTOR event

### DIFF
--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -26,7 +26,6 @@ export const eventsData: Record<string, EventTemplates[]> = {
     {
       id: 'FAA_INSPECTOR',
       type: 'audit',
-      // FIX: Changed 'suit' to 'suitType' to match the GameEvent interface.
       suitType: 'FAA_INSPECTOR',
       title: 'FAA Spot-Check',
       description:


### PR DESCRIPTION
Removed obsolete comment from `src/data/events.ts`.

---
*PR created automatically by Jules for task [8171408718411687884](https://jules.google.com/task/8171408718411687884) started by @stevenselcuk*