### PR TITLE
chore: remove completed FIX comment for AUDIT_INTERNAL

### DIFF
--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -49,7 +49,6 @@ export const eventsData: Record<string, EventTemplates[]> = {
     {
       id: 'AUDIT_INTERNAL',
       type: 'audit',
-      // FIX: Changed 'suit' to 'suitType' to match the GameEvent interface.
       suitType: 'INTERNAL_SECURITY',
       title: 'Internal Log Review',
       description:


### PR DESCRIPTION
This PR removes an outdated `// FIX:` comment in `src/data/events.ts` related to the `AUDIT_INTERNAL` event. The comment noted a property change from `suit` to `suitType`, but the implementation code directly below the comment already reflected this change (`suitType: 'INTERNAL_SECURITY'`).

Therefore, the comment was obsolete and has been removed to keep the codebase clean. I have also run the full test suite and linter to ensure no syntax issues or regressions were introduced.

---
*PR created automatically by Jules for task [8521361690639042351](https://jules.google.com/task/8521361690639042351) started by @stevenselcuk*