### PR TITLE
Remove outdated suitType comments

### DIFF
--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -26,7 +26,6 @@ export const eventsData: Record<string, EventTemplates[]> = {
     {
       id: 'FAA_INSPECTOR',
       type: 'audit',
-      // FIX: Changed 'suit' to 'suitType' to match the GameEvent interface.
       suitType: 'FAA_INSPECTOR',
       title: 'FAA Spot-Check',
       description:
@@ -49,7 +48,6 @@ export const eventsData: Record<string, EventTemplates[]> = {
     {
       id: 'AUDIT_INTERNAL',
       type: 'audit',
-      // FIX: Changed 'suit' to 'suitType' to match the GameEvent interface.
       suitType: 'INTERNAL_SECURITY',
       title: 'Internal Log Review',
       description:
@@ -72,7 +70,6 @@ export const eventsData: Record<string, EventTemplates[]> = {
     {
       id: 'AUDIT_SUITS',
       type: 'audit',
-      // FIX: Changed 'suit' to 'suitType' to match the GameEvent interface.
       suitType: 'THE_SUITS',
       title: 'Unscheduled Oversight',
       description:


### PR DESCRIPTION
Removed obsolete `// FIX: Changed 'suit' to 'suitType' to match the GameEvent interface.` comments from `src/data/events.ts`. This was a cleanup task as the property rename was already implemented. Tests and linters were run to ensure nothing broke.

---
*PR created automatically by Jules for task [9107945396351137844](https://jules.google.com/task/9107945396351137844) started by @stevenselcuk*